### PR TITLE
Save color and IR streams along with depth in Realsense

### DIFF
--- a/lib/camera/realsense_cam.cpp
+++ b/lib/camera/realsense_cam.cpp
@@ -28,13 +28,13 @@ namespace camera {
                                             CV_16UC1, (void*)depth.get_data(), cv::Mat::AUTO_STEP);
             cv::imwrite(path_ + frame_postfix, display_depth);
             metadata_to_csv(depth, path_+csv_postfix);
-            if (save_color){
+            if (save_color_){
                 cv::Mat display_color = cv::Mat(cv::Size(color.as<rs2::video_frame>().get_width(), color.as<rs2::video_frame>().get_height()),
                                                 CV_8UC3, (void*)color.get_data(), cv::Mat::AUTO_STEP);
                 cv::imwrite(path_ + "_rgb" + frame_postfix, display_color);
                 metadata_to_csv(color, path_ + "_rgb" + csv_postfix);
               }
-            if (save_ir) {
+            if (save_ir_) {
                 cv::Mat display_infra = cv::Mat(cv::Size(infra.as<rs2::video_frame>().get_width(), infra.as<rs2::video_frame>().get_height()),
                                                 CV_8UC1, (void*)infra.get_data(), cv::Mat::AUTO_STEP);
                 cv::imwrite(path_ + "_infra" + frame_postfix, display_infra);

--- a/lib/camera/realsense_cam.h
+++ b/lib/camera/realsense_cam.h
@@ -12,8 +12,8 @@ namespace camera {
                 record_(false),
                 seq_(0),
                 path_(""),
-                save_ir(true),
-                save_color(true){
+                save_ir_(true),
+                save_color_(true){
             dvc_ = ctx.query_devices()[idx];
 
             rs2::config cfg;
@@ -47,8 +47,8 @@ namespace camera {
         bool record_;
         int seq_;
         std::string path_;
-        bool save_ir;
-        bool save_color;
+        bool save_ir_;
+        bool save_color_;
     };
 
 }


### PR DESCRIPTION
Saving color and IR streams from the realsense L515 along with depth
Saving depth as 16-bit single channel PNG, but displaying as color-coded image